### PR TITLE
generator.pyの最大出力トークン数を8192から32768に増加させ、生成コンテンツの能力を向上させました。

### DIFF
--- a/app/generator.py
+++ b/app/generator.py
@@ -348,7 +348,7 @@ HotPepper Beautyの人気サロンで使用されている、効果的なタイ�
             try:
                 config_with_thinking = types.GenerateContentConfig(
                     temperature=0.7,
-                    max_output_tokens=8192,
+                    max_output_tokens=32768,
                     thinking_config=types.ThinkingConfig(
                         thinking_budget=0  # 高速化のため思考プロセスを無効化
                     )
@@ -365,7 +365,7 @@ HotPepper Beautyの人気サロンで使用されている、効果的なタイ�
                 # 旧SDKにフォールバック
                 generation_config = genai.GenerationConfig(
                     temperature=0.7,
-                    max_output_tokens=8192,
+                    max_output_tokens=32768,
                 )
                 response = await self.model.generate_content_async(prompt, generation_config=generation_config)
                 response_text = response.text


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Raise `max_output_tokens` from 8192 to 32768 for both the new SDK `GenerateContentConfig` and legacy `GenerationConfig` in `app/generator.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 550329d5365a6b28923ab31c8f234ed87175c980. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->