### PR TITLE
メンテナンス告知バナーをトップページに追加

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,4 +1,6 @@
 import os
+from datetime import datetime
+from zoneinfo import ZoneInfo
 from dotenv import load_dotenv
 
 # Load environment variables
@@ -48,6 +50,16 @@ PV_BOOST_KEYWORDS = [
     "冬カラー",
 ]
 PV_BOOST_COUNT_PER_KEYWORD = 2
+
+# Maintenance Notice
+JST = ZoneInfo('Asia/Tokyo')
+
+# 臨時システムメンテナンス告知（'end' を過ぎると自動的に非表示になる。終了後はこの定数と関連コードを削除する）
+MAINTENANCE_NOTICE = {
+    'end': datetime(2026, 7, 21, 8, 0, tzinfo=JST),
+    'message': 'HOT PEPPER Beauty／SALON BOARD の臨時システムメンテナンスのため、'
+               '7月21日(火) 1:00〜8:00頃は本アプリのタイトル生成をご利用いただけません。',
+}
 
 # Flask Settings
 class Config:

--- a/app/main.py
+++ b/app/main.py
@@ -1,13 +1,14 @@
 import os
 import logging
 # import asyncio # Removed as run_async_task is deleted
+from datetime import datetime
 from typing import List, Dict, Tuple
 from logging.handlers import RotatingFileHandler
 from flask import Blueprint, render_template, request, jsonify, current_app
 from werkzeug.exceptions import BadRequest
 from .scraping import HotPepperScraper
 from .generator import TemplateGenerator
-from .config import GEMINI_API_KEY
+from .config import GEMINI_API_KEY, JST, MAINTENANCE_NOTICE
 from .featured_keywords import FeaturedKeywordsManager
 from . import featured_keywords
 
@@ -98,11 +99,19 @@ def favicon():
     """faviconのルート"""
     return current_app.send_static_file('favicon.ico')
 
+def get_maintenance_notice():
+    """メンテナンス告知の文言を返す。期間終了後・未設定の場合は None。"""
+    if not MAINTENANCE_NOTICE:
+        return None
+    if datetime.now(JST) >= MAINTENANCE_NOTICE['end']:
+        return None
+    return MAINTENANCE_NOTICE['message']
+
 @main_bp.route('/')
 def index():
     """トップページのルート"""
     current_app.logger.info('トップページにアクセスがありました')
-    return render_template('index.html')
+    return render_template('index.html', maintenance_notice=get_maintenance_notice())
 
 @main_bp.route('/api/featured-keywords', methods=['GET'])
 def get_featured_keywords():

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -928,6 +928,50 @@ input[type="text"]:focus+.search-icon {
     }
 }
 
+/* メンテナンス告知バナー */
+.maintenance-notice {
+    background-color: rgba(77, 166, 255, 0.08);
+    color: var(--text-color);
+    padding: var(--spacing-md) var(--spacing-lg);
+    border-radius: var(--border-radius-lg);
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    max-width: 700px;
+    margin: var(--spacing-lg) auto 0;
+    border-left: 4px solid var(--warning-color);
+    box-shadow: var(--shadow-sm);
+    font-weight: 500;
+    line-height: 1.6;
+}
+
+.maintenance-notice i {
+    font-size: 1.4rem;
+    color: var(--warning-color);
+    background-color: rgba(77, 166, 255, 0.12);
+    width: 36px;
+    height: 36px;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+}
+
+@media (max-width: 576px) {
+    .maintenance-notice {
+        margin: var(--spacing-md) auto 0;
+        padding: var(--spacing-sm) var(--spacing-md);
+        font-size: 0.85rem;
+    }
+
+    .maintenance-notice i {
+        font-size: 1.1rem;
+        width: 28px;
+        height: 28px;
+    }
+}
+
 /* エラーメッセージ */
 .error-message {
     background-color: rgba(239, 71, 111, 0.08);

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -10,6 +10,13 @@
     </div>
 </header>
 
+{% if maintenance_notice %}
+<div class="maintenance-notice" role="status">
+    <i class="fas fa-triangle-exclamation"></i>
+    <span>{{ maintenance_notice }}</span>
+</div>
+{% endif %}
+
 <main class="app-main">
     <div class="container">
         <!-- 検索セクションを独立させる -->

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,8 @@
 import pytest
 from app import create_app
+from app.config import JST
 import json
+from datetime import datetime, timedelta
 from unittest.mock import patch, AsyncMock
 
 @pytest.fixture
@@ -20,6 +22,30 @@ def test_index_route(client):
     response = client.get('/')
     assert response.status_code == 200
     assert 'ヘアスタイルタイトルジェネレーター' in response.data.decode('utf-8')
+
+def test_index_shows_maintenance_notice_before_end(client, monkeypatch):
+    """メンテナンス終了前: 告知バナーが表示される"""
+    notice = {
+        'end': datetime.now(JST) + timedelta(days=1),
+        'message': 'テスト用メンテナンス告知',
+    }
+    monkeypatch.setattr('app.main.MAINTENANCE_NOTICE', notice)
+
+    response = client.get('/')
+    assert response.status_code == 200
+    assert 'テスト用メンテナンス告知' in response.data.decode('utf-8')
+
+def test_index_hides_maintenance_notice_after_end(client, monkeypatch):
+    """メンテナンス終了後: 告知バナーが表示されない"""
+    notice = {
+        'end': datetime.now(JST) - timedelta(days=1),
+        'message': 'テスト用メンテナンス告知',
+    }
+    monkeypatch.setattr('app.main.MAINTENANCE_NOTICE', notice)
+
+    response = client.get('/')
+    assert response.status_code == 200
+    assert 'テスト用メンテナンス告知' not in response.data.decode('utf-8')
 
 def test_generate_templates_route_success(client):
     """正常系: テンプレート生成が成功するケース"""


### PR DESCRIPTION
## 概要

HOT PEPPER Beauty／SALON BOARD の臨時システムメンテナンス（**2026年7月21日(火) 1:00〜8:00頃 JST**）を告知するバナーをトップページに追加します。

該当時間帯は HotPepper Beauty へのアクセスが全面停止するため、本アプリのタイトル生成は必ず失敗します。ユーザーが原因不明のエラーに遭遇する前に周知するのが目的です。

## 変更内容

| ファイル | 内容 |
|---|---|
| `app/config.py` | `JST` と `MAINTENANCE_NOTICE` 定数（終了日時 + 告知文）を追加 |
| `app/main.py` | `get_maintenance_notice()` を追加し、`/` から `index.html` に渡す |
| `app/templates/index.html` | ヘッダー直下にバナーを条件描画 |
| `app/static/css/style.css` | `.maintenance-notice`（既存 `.error-message` の様式を踏襲、青系 `--warning-color`） |
| `tests/test_main.py` | 終了前は表示・終了後は非表示、の2ケースを追加 |

## 設計メモ

- **告知のみ**で API のブロックは行いません。
- **7月21日 8:00 JST を過ぎるとバナーは自動的に消えます**。サーバーが UTC（Render）でも `datetime.now(JST)` で判定するため正しく動作します。
- メンテナンス終了後は `MAINTENANCE_NOTICE` と関連コードを削除するのが望ましいです（残しても実害はありません）。

## テスト

- `pytest tests/test_main.py` → 8 passed
- UI/integration を除く全体 → 80 passed（UI テストは selenium 未インストールのため元から実行不可）
- 実日時でトップページをレンダリングし、バナーの描画を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)